### PR TITLE
Fix postgres executor configuration

### DIFF
--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -3,4 +3,5 @@ docker:
   - image: circleci/postgres:9.4.11
     environment:
       RAILS_ENV: test
+      DB: postgres
       DATABASE_URL: postgresql://root@127.0.0.1/circle_test?pool=5


### PR DESCRIPTION
`DB=postgres` was not set so tests was running against the default database (`sqlite`)