### PR TITLE
Update Ruby version to 2.4.7

### DIFF
--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.4.2-node-browsers
+  - image: circleci/ruby:2.4.7-node-browsers
   - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
   - image: circleci/mysql:5.7-ram
     environment:

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.4.2-node-browsers
+  - image: circleci/ruby:2.4.7-node-browsers
   - image: circleci/mysql:5.7-ram
     environment:
       RAILS_ENV: test

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.4.2-node-browsers
+  - image: circleci/ruby:2.4.7-node-browsers
   - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
   - image: circleci/postgres:9.4.11
     environment:

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.4.2-node-browsers
+  - image: circleci/ruby:2.4.7-node-browsers
   - image: circleci/postgres:9.4.11
     environment:
       RAILS_ENV: test


### PR DESCRIPTION
Now that we support Rails 6, extensions are built against a Rails 6 dummy app which uses Zeitwerk, which in turn requires Ruby >= 2.4.4.