### PR TITLE
Save gems cache before running the tests

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -17,8 +17,8 @@ steps:
         - gems-v2-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         - gems-v2-ruby-v2-5-6-solidus-<<parameters.branch>>-
   - run:
-      name: 'Runs tests on Solidus <<parameters.branch>>'
-      command: bundle install --path=vendor/bundle && bundle exec rake
+      name: 'Solidus <<parameters.branch>>:  Install gems'
+      command: bundle install --path=vendor/bundle
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
   - save_cache:
@@ -26,6 +26,11 @@ steps:
       key: gems-v2-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle
+  - run:
+      name: 'Runs tests on Solidus <<parameters.branch>>'
+      command: bundle exec rake
+      environment:
+        SOLIDUS_BRANCH: <<parameters.branch>>
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy
       name: 'Solidus <<parameters.branch>>: Clean up'


### PR DESCRIPTION
Separates the `bundle install` and `bundle exec rake` commands in two steps, and saves the Bundler cache between the two. This way, even if `bundle exec rake` fails, the Bundler cache has already been saved and can be reused for subsequent test runs, which is especially useful to save time when iterating on a CircleCI failure.