### PR TITLE
Bump gem cache to fix an issue with solidus tags

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -14,8 +14,8 @@ steps:
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
-        - gems-v2-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - gems-v2-ruby-v2-5-6-solidus-<<parameters.branch>>-
+        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
       command: bundle install --path=vendor/bundle
@@ -23,7 +23,7 @@ steps:
         SOLIDUS_BRANCH: <<parameters.branch>>
   - save_cache:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
-      key: gems-v2-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle
   - run:


### PR DESCRIPTION
There was a wrong tag set on solidus core (v2.9). This tag was selected as ref from some extensions since v2.9 takes precedence on v2.9.1 for instance.

This bump fixes builds that still uses the cached version at that tag reference, which has been removed.