### PR TITLE
Avoid blocking other versions specs if one fails

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -11,26 +11,32 @@ steps:
       command: bundle lock
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
+      when: always
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
         - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
+      when: always
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
       command: bundle install --path=vendor/bundle
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
+      when: always
   - save_cache:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
       key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle
+      when: always
   - run:
       name: 'Runs tests on Solidus <<parameters.branch>>'
       command: bundle exec rake
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
+      when: always
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy
       name: 'Solidus <<parameters.branch>>: Clean up'
+      when: always


### PR DESCRIPTION
**WIP**: needs to be tested

At the moment if an extension specs run fails at one specific Solidus version (let's say 2.5), all the other steps are not performed. This makes hard to have a complete matrix in every scenario.

Using [`when: always`][1] ensure all the steps are executed, even if one of them fails.

[1]: https://circleci.com/docs/2.0/configuration-reference/#steps

Closes #7 
