### PR TITLE
Support CircleCI test results

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -35,7 +35,10 @@ steps:
       command: bundle exec rake
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
+        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
       when: always
+  - store_test_results:
+      path: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy
       name: 'Solidus <<parameters.branch>>: Clean up'


### PR DESCRIPTION
Ref: https://circleci.com/docs/2.0/configuration-reference/#store_test_results

This change allows CircleCI to nicely show the errors of the build in a nice summary view.

The typical way this will be used is to add the JUnit RSpec formatter and point its output toward the path set as environment variable:

```rb
RSpec::Core::RakeTask.new(:specs) do |t|
  # Ref: https://circleci.com/docs/2.0/configuration-reference/#store_test_results
  if ENV['TEST_RESULTS_PATH']
    t.rspec_opts =
      "--format progress " \
      "--format RspecJunitFormatter --out #{ENV['TEST_RESULTS_PATH']}"
  end
end
```