### PR TITLE
Support CircleCI test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ workflows:
 Be sure to also enable building the project on CircleCI, otherwise it won't
 do anything.
 
+### Test Results (RSpec)
+
+To enable CircleCI Test Results be sure to include `rspec_junit_formatter` in your gemspec:
+
+    spec.add_development_dependency 'rspec_junit_formatter'
+
+And to properly setup the RSpec Rake task to generate the results XML output:
+
+```rb
+RSpec::Core::RakeTask.new(:specs) do |t|
+  # Ref: https://circleci.com/docs/2.0/configuration-reference/#store_test_results
+  if ENV['TEST_RESULTS_PATH']
+    t.rspec_opts =
+      "--format progress " \
+      "--format RspecJunitFormatter --out #{ENV['TEST_RESULTS_PATH']}"
+  end
+end
+```
+
 ## Contributing
 
 We accept Pull Requests on this repository. Any kind of contrubution is welcome.

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -13,3 +13,6 @@ steps:
       branch: v2.9
   - test-branch:
       branch: master
+  - store_test_results:
+      path: test-results
+

--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -35,6 +35,7 @@ steps:
       command: bundle exec rake
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
+        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
       when: always
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy


### PR DESCRIPTION
Ref: https://circleci.com/docs/2.0/configuration-reference/#store_test_results
Fixes #16 

This change allows CircleCI to nicely show the errors of the build in a nice summary view.

The typical way this will be used is to add the JUnit RSpec formatter and point its output toward the path set as environment variable:

```rb
RSpec::Core::RakeTask.new(:specs) do |t|
  # Ref: https://circleci.com/docs/2.0/configuration-reference/#store_test_results
  if ENV['TEST_RESULTS_PATH']
    t.rspec_opts =
      "--format progress " \
      "--format RspecJunitFormatter --out #{ENV['TEST_RESULTS_PATH']}"
  end
end
```

## Screenshots

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/1051/66648332-9475ae80-ec2b-11e9-87a9-fcb9dc17e715.png">


<img width="1552" alt="image" src="https://user-images.githubusercontent.com/1051/66648401-b838f480-ec2b-11e9-9ae0-db97fe673058.png">
