### PR TITLE
Allow the test_app to use the correct database

### DIFF
--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -1,8 +1,11 @@
 docker:
   - image: circleci/ruby:2.5.6-node-browsers
+    environment:
+      DB: mysql
+      RAILS_ENV: test
+      DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
   - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
   - image: circleci/mysql:5.7-ram
     environment:
-      RAILS_ENV: test
-      DB: mysql
-      DB_HOST: 127.0.0.1
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_ROOT_HOST: '%'

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -1,7 +1,10 @@
 docker:
   - image: circleci/ruby:2.5.6-node-browsers
+    environment:
+      DB: mysql
+      RAILS_ENV: test
+      DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
   - image: circleci/mysql:5.7-ram
     environment:
-      RAILS_ENV: test
-      DB: mysql
-      DB_HOST: 127.0.0.1
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_ROOT_HOST: '%'

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -1,8 +1,11 @@
 docker:
   - image: circleci/ruby:2.5.6-node-browsers
+    environment:
+      DB: postgresql
+      PGHOST: 127.0.0.1
+      PGUSER: root
+      RAILS_ENV: test
   - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
   - image: circleci/postgres:9.4.11
     environment:
-      RAILS_ENV: test
-      DB: postgres
-      DATABASE_URL: postgresql://root@127.0.0.1/circle_test?pool=5
+      POSTGRES_USER: root

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -1,7 +1,10 @@
 docker:
   - image: circleci/ruby:2.5.6-node-browsers
+    environment:
+      DB: postgresql
+      PGHOST: 127.0.0.1
+      PGUSER: root
+      RAILS_ENV: test
   - image: circleci/postgres:9.4.11
     environment:
-      RAILS_ENV: test
-      DB: postgres
-      DATABASE_URL: postgresql://root@127.0.0.1/circle_test?pool=5
+      POSTGRES_USER: root


### PR DESCRIPTION
The `test_app` task uses the `DB` env var to build the dummy app using the correct database: MySQL or Postgres.

Set the ENV var to the correct Docker container to make it works.