### PR TITLE
Use semantic Solidus versions

### DIFF
--- a/src/commands/run-tests-solidus-current.yml
+++ b/src/commands/run-tests-solidus-current.yml
@@ -1,0 +1,6 @@
+description: >
+  Test latest release of Solidus
+
+steps:
+  - test-branch:
+      branch: v2.9

--- a/src/commands/run-tests-solidus-master.yml
+++ b/src/commands/run-tests-solidus-master.yml
@@ -1,0 +1,7 @@
+description: >
+  Test the edge version of Solidus
+
+steps:
+  - test-branch:
+      branch: master
+

--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -1,0 +1,8 @@
+description: >
+  Test older releases of Solidus
+
+steps:
+  - test-branch:
+      branch: v2.6
+  - test-branch:
+      branch: v2.7

--- a/src/commands/run-tests-solidus-previous.yml
+++ b/src/commands/run-tests-solidus-previous.yml
@@ -1,0 +1,6 @@
+description: >
+  Test second latest release of Solidus
+
+steps:
+  - test-branch:
+      branch: v2.8

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -3,14 +3,10 @@ description: >
 
 steps:
   - checkout
-  - test-branch:
-      branch: v2.6
-  - test-branch:
-      branch: v2.7
-  - test-branch:
-      branch: v2.8
-  - test-branch:
-      branch: v2.9
+  - run-tests-solidus-older
+  - run-tests-solidus-previous
+  - run-tests-solidus-current
+  - run-tests-solidus-master
   - test-branch:
       branch: master
   - store-test-results

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -13,6 +13,4 @@ steps:
       branch: v2.9
   - test-branch:
       branch: master
-  - store_test_results:
-      path: test-results
-
+  - store-test-results

--- a/src/commands/store-test-results.yml
+++ b/src/commands/store-test-results.yml
@@ -1,0 +1,7 @@
+description: >
+  Save test results
+
+steps:
+  - store_test_results:
+      path: test-results
+

--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -1,0 +1,7 @@
+docker:
+  - image: circleci/ruby:2.5.6-node-browsers
+    environment:
+      RAILS_ENV: test
+      DB: sqlite
+      DATABASE_URL: sqlite3::memory:?pool=1
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true


### PR DESCRIPTION
Allow users to target a specific semantic group and allow them to mix
and match them independently. Every group will target a single version
except for the "older" group that will include all versions from the
last third (included) down to the oldest supported version.

Using a configuration like this:

```yml
    jobs:
      - solidusio_extensions/run-specs-master
      - solidusio_extensions/run-specs-current
      - solidusio_extensions/run-specs-previous
      - solidusio_extensions/run-specs-older
```

Brought the CI time from 20m down to 5m.