### PR TITLE
Use semantic Solidus versions

### DIFF
--- a/src/commands/run-tests-solidus-current.yml
+++ b/src/commands/run-tests-solidus-current.yml
@@ -1,0 +1,6 @@
+description: >
+  Test latest release of Solidus
+
+steps:
+  - test-branch:
+      branch: v2.9

--- a/src/commands/run-tests-solidus-master.yml
+++ b/src/commands/run-tests-solidus-master.yml
@@ -1,0 +1,7 @@
+description: >
+  Test the edge version of Solidus
+
+steps:
+  - test-branch:
+      branch: master
+

--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -1,0 +1,8 @@
+description: >
+  Test older releases of Solidus
+
+steps:
+  - test-branch:
+      branch: v2.8
+  - test-branch:
+      branch: v2.7

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -3,12 +3,7 @@ description: >
 
 steps:
   - checkout
-  - test-branch:
-      branch: v2.7
-  - test-branch:
-      branch: v2.8
-  - test-branch:
-      branch: v2.9
-  - test-branch:
-      branch: master
+  - run-tests-solidus-older
+  - run-tests-solidus-current
+  - run-tests-solidus-master
   - store-test-results

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -11,6 +11,4 @@ steps:
       branch: v2.9
   - test-branch:
       branch: master
-  - store_test_results:
-      path: test-results
-
+  - store-test-results

--- a/src/commands/store-test-results.yml
+++ b/src/commands/store-test-results.yml
@@ -1,0 +1,7 @@
+description: >
+  Save test results
+
+steps:
+  - store_test_results:
+      path: test-results
+


### PR DESCRIPTION
_this PR replaces #18_

Allow users to target a specific semantic group and allow them to mix
and match them independently. Every group will target a single version
except for the "older" group that will include all versions from the
last third (included) down to the oldest supported version.

Using a configuration like this:

```yml
    jobs:
      - solidusio_extensions/run-specs-master
      - solidusio_extensions/run-specs-current
      - solidusio_extensions/run-specs-previous
      - solidusio_extensions/run-specs-older
```

Brought the CI time from 20m down to less than 3m.

### Why is it faster?

The default way of running specs across multiple Solidus versions is to do that sequentially within a single job. By doing that in parallel instead of having to wait the sum total times for each Solidus version it will allow to wait just for the slowest one. So if each version will take 1 minute each, testing against 5 versions will result in a 5 minutes build, but doing that with parallelism = 4 will go down to 2 minutes.

### See it in action ⚔️ 

https://github.com/solidusio-contrib/solidus_dev_support/pull/44