### PR TITLE
Prevent orb-tools to update to the latest major

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@volatile
+  orb-tools: circleci/orb-tools@8
 
 workflows:
   lint_pack-validate_publish-dev:


### PR DESCRIPTION
V9 has breaking changes that break the current CI config.