### PR TITLE
Add an in-memory sqlite executor

### DIFF
--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -1,0 +1,7 @@
+docker:
+  - image: circleci/ruby:2.5.6-node-browsers
+    environment:
+      RAILS_ENV: test
+      DB: sqlite
+      DATABASE_URL: sqlite3::memory:?pool=1
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true


### PR DESCRIPTION
This will come useful for faster CI execution for specs that don't
really use the database. 

_Extracted from #19_