### PR TITLE
Fix test execution order for older versions of Solidus

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -3,8 +3,8 @@ description: >
 
 steps:
   - test-branch:
-      branch: v2.9
+      branch: v2.7
   - test-branch:
       branch: v2.8
   - test-branch:
-      branch: v2.7
+      branch: v2.9


### PR DESCRIPTION
Fixes the execution order of tests for older versions of Solidus. Currently, it's running 2.9, then 2.8, then 2.7, which is a bit weird (although not a real bug).