### PR TITLE
Remove v2.7 branch since 2.7 is EOL

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -3,8 +3,6 @@ description: >
 
 steps:
   - test-branch:
-      branch: v2.7
-  - test-branch:
       branch: v2.8
   - test-branch:
       branch: v2.9


### PR DESCRIPTION
2.7.0 was released at 09/14/2018 and according to the Version Guidelines
it's end of life is 03/14/2020.

This commits removes the branch from the testing support.