### PR TITLE
Bundle clean

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -23,6 +23,7 @@ steps:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
         - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-master
         - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
       when: always
   - run:

--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -27,7 +27,9 @@ steps:
       when: always
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
-      command: bundle install --path=vendor/bundle
+      command: |
+        bundle install --path=vendor/bundle-<<parameters.branch>>
+        bundle clean
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
       when: always
@@ -35,7 +37,7 @@ steps:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
       key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
-        - vendor/bundle
+        - vendor/bundle-<<parameters.branch>>
       when: always
   - run:
       name: '<<parameters.command_verb>> on Solidus <<parameters.branch>>'


### PR DESCRIPTION
Ensure old gems are cleaned after a new bundle install and that we have a different gem cache for each solidus branch.

The reason is that recently I caught a repo that spent 5min restoring and then saving more than 5GB of cache. This change will ensure all unused gem and git versions are pruned and that old solidus version caches will be abandoned once the support for that version is dropped.

This change was tried here https://github.com/solidusio-contrib/solidus_importer/pull/32

Before:
<img width="1361" alt="image" src="https://user-images.githubusercontent.com/1051/89790571-6a7a6a80-db22-11ea-9521-7388d66ae5d8.png">
https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_importer/263/workflows/1a2db93d-25f2-46f6-8f94-bb5226b776e8/jobs/555

After:
<img width="921" alt="image" src="https://user-images.githubusercontent.com/1051/89989299-0cb06480-dc81-11ea-88e4-50787fee1786.png">
https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_importer/272/workflows/91ab5c28-51eb-4a6c-83e7-068eb1ef8ed1/jobs/571