### PR TITLE
Keep cached bundles into vendor/bundle

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -29,7 +29,11 @@ steps:
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
       command: |
-        bundle install --path=vendor/bundle-<<parameters.branch>>
+        # Migrate old bundles to the new path (previously was vendor/bundle-<<parameters.branch>>)
+        mkdir -p vendor/bundle
+        test -d vendor/bundle-<<parameters.branch>> && mv vendor/bundle-<<parameters.branch>> vendor/bundle/<<parameters.branch>> || true
+
+        bundle install --path=vendor/bundle/<<parameters.branch>>
         bundle clean
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
@@ -38,7 +42,7 @@ steps:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
       key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
-        - vendor/bundle-<<parameters.branch>>
+        - vendor/bundle/<<parameters.branch>>
       when: always
   - run:
       name: '<<parameters.command_verb>> on Solidus <<parameters.branch>>'


### PR DESCRIPTION
Many tools are already configured to ignore the vendor/bundle path.
By moving to subfolders we avoid reconfiguring them while still
retaining the benefits of per-branch bundles.


The command also includes a couple of lines to support the migration from the old path, saving a ton of time for all extensions that will get this update. The migration code will be removed after Dec 1 2020, see https://github.com/solidusio/circleci-orbs-extensions/issues/30.

---

**Before:**

https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_paypal_commerce_platform/255/workflows/f2e785b8-c256-4771-9477-110cb03f165c/jobs/638

<img width="969" alt="image" src="https://user-images.githubusercontent.com/1051/92104597-d5e1f000-ede1-11ea-8513-602469896b2a.png">

**After:**

https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_paypal_commerce_platform/259/workflows/b65034e9-e64f-498b-b1e2-f0babfdd3659/jobs/651

<img width="907" alt="image" src="https://user-images.githubusercontent.com/1051/92112269-cff20c00-eded-11ea-91e2-dc5fa863b13b.png">

<img width="588" alt="image" src="https://user-images.githubusercontent.com/1051/92112332-e8fabd00-eded-11ea-8647-25d041fe51d8.png">
