### PR TITLE
Update versions

### DIFF
--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -5,7 +5,7 @@ docker:
       DB: mysql
       RAILS_ENV: test
       DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
-  - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+  - image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
   - image: cimg/mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -6,7 +6,7 @@ docker:
       PGHOST: 127.0.0.1
       PGUSER: root
       RAILS_ENV: test
-  - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+  - image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
   - image: cimg/postgres:14.2
     environment:
       POSTGRES_USER: root


### PR DESCRIPTION
Using outdated versions can translate into significant differences with the current production or local setups.
Given the CI is there to catch problems before they hit production seems reasonable to live on the (stable) edge.

Ruby, as before, is pinned to the oldest supported release to avoid moving to new syntaxes that can break older supported versions, but we expect users will stay up-to-date with the patch version.

All DBs have been moved to RAM so that everything should run faster.