### PR TITLE
Remove Solidus 2.8 from the build matrix

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -3,6 +3,4 @@ description: >
 
 steps:
   - test-branch:
-      branch: v2.8
-  - test-branch:
       branch: v2.9


### PR DESCRIPTION
Removes Solidus 2.8 from the build matrix, since it [reached EOL](https://solidus.io/security/) on 2020-07-29.