### PR TITLE
Store Rails screenshots in artifacts

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -51,6 +51,10 @@ steps:
         SOLIDUS_BRANCH: <<parameters.branch>>
         TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
       when: always
+  - store_artifacts:
+      name: 'Solidus <<parameters.branch>>: Store spec screenshots'
+      path: spec/dummy/tmp/screenshots
+      destination: screenshots
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy
       name: 'Solidus <<parameters.branch>>: Clean up'


### PR DESCRIPTION
When using system specs, Rails automatically generate screenshots for failing tests using [ScreenshotHelper](https://api.rubyonrails.org/v6.0.3/classes/ActionDispatch/SystemTesting/TestHelpers/ScreenshotHelper.html) but it has no options to set the output path.

This PR aims to copy the screenshots in artifacts before they get deleted in _Solidus Clean up_ step.