### PR TITLE
Ruby 2.5 has reached EOL, bump environment to 2.6

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -22,9 +22,9 @@ steps:
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
-        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-master
-        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
+        - gems-v3-ruby-v2-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - gems-v3-ruby-v2-6-solidus-<<parameters.branch>>-master
+        - gems-v3-ruby-v2-6-solidus-<<parameters.branch>>-
       when: always
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
@@ -36,7 +36,7 @@ steps:
       when: always
   - save_cache:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
-      key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      key: gems-v3-ruby-v2-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle/<<parameters.branch>>
       when: always
@@ -45,7 +45,7 @@ steps:
       command: <<parameters.command>>
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
-        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
+        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-6-solidus-<<parameters.branch>>/results.xml
       when: always
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy

--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: circleci/ruby:2.6-node-browsers
     environment:
       DB: mysql
       RAILS_ENV: test

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: circleci/ruby:2.6-node-browsers
     environment:
       DB: mysql
       RAILS_ENV: test

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: circleci/ruby:2.6-node-browsers
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: circleci/ruby:2.6-node-browsers
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1

--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: circleci/ruby:2.6-node-browsers
     environment:
       RAILS_ENV: test
       DB: sqlite


### PR DESCRIPTION
Ruby 2.5 has reached EOL and will no longer recieve any security
patches. Bumped environment for CI to 2.6 as it is best practiced to use
a maintained version of Ruby. Ruby 2.6 EOL slated for March 31, 2022