### PR TITLE
[semver:major] Ruby 2.5 and Ruby 2.6 has reached EOL, bump CI environment to 2.7 

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -22,9 +22,9 @@ steps:
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
-        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-master
-        - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
+        - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-master
+        - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-
       when: always
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
@@ -36,7 +36,7 @@ steps:
       when: always
   - save_cache:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
-      key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      key: gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle/<<parameters.branch>>
       when: always
@@ -45,7 +45,7 @@ steps:
       command: <<parameters.command>>
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
-        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
+        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-7-solidus-<<parameters.branch>>/results.xml
       when: always
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy

--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -5,7 +5,7 @@ docker:
       RAILS_ENV: test
       DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
   - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
-  - image: circleci/mysql:5.7-ram
+  - image: cimg/mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
       MYSQL_ROOT_HOST: '%'

--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: cimg/ruby:2.7-browsers
     environment:
       DB: mysql
       RAILS_ENV: test

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: cimg/ruby:2.7-browsers
     environment:
       DB: mysql
       RAILS_ENV: test

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -4,7 +4,7 @@ docker:
       DB: mysql
       RAILS_ENV: test
       DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
-  - image: circleci/mysql:5.7-ram
+  - image: cimg/mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
       MYSQL_ROOT_HOST: '%'

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -6,6 +6,6 @@ docker:
       PGUSER: root
       RAILS_ENV: test
   - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
-  - image: circleci/postgres:9.4.11
+  - image: cimg/postgres:14.2
     environment:
       POSTGRES_USER: root

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: cimg/ruby:2.7-browsers
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -5,6 +5,6 @@ docker:
       PGHOST: 127.0.0.1
       PGUSER: root
       RAILS_ENV: test
-  - image: circleci/postgres:9.4.11
+  - image: cimg/postgres:14.2
     environment:
       POSTGRES_USER: root

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: cimg/ruby:2.7-browsers
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1

--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/ruby:2.5.6-node-browsers
+  - image: cimg/ruby:2.7-browsers
     environment:
       RAILS_ENV: test
       DB: sqlite


### PR DESCRIPTION
Ruby 2.6 has reached EOL and will no longer receive any security
patches after March 31, 2022. Bumped version requirements to 2.7 as
it is best practiced to use a maintained version of Ruby.