### PR TITLE
Run `bundle update solidus` every time

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -29,8 +29,8 @@ steps:
   - run:
       name: 'Solidus <<parameters.branch>>:  Install gems'
       command: |
-        bundle install --path=vendor/bundle/<<parameters.branch>>
-        bundle clean
+        bundle install --path=vendor/bundle/<<parameters.branch>> --clean
+        bundle update solidus
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
       when: always


### PR DESCRIPTION
We discovered that solidus master was not being updated because a simple `install` was relying on the restored cache.

E.g. in https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_subscriptions/693/workflows/f5d183ae-4dd7-4cea-a502-7c4dee49624e/jobs/1875 we fetched solidus_core 3.2.0.alpha from https://github.com/solidusio/solidus.git at master@094bd7d instead of master@d467123b9.
