### PR TITLE
Fix container configuration

### DIFF
--- a/src/examples/extension.yml
+++ b/src/examples/extension.yml
@@ -4,6 +4,9 @@ usage:
   version: 2.1
 
   orbs:
+    # Required for feature specs.
+    browser-tools: circleci/browser-tools@1.1
+
     # Always take the latest version of the Orb, this allows us to
     # run specs against Solidus supported versions only without the need
     # to change this configuration every time a Solidus version is released
@@ -14,10 +17,12 @@ usage:
     run-specs-with-postgres:
       executor: solidusio_extensions/postgres
       steps:
+        - browser-tools/install-browser-tools
         - solidusio_extensions/run-tests
     run-specs-with-mysql:
       executor: solidusio_extensions/mysql
       steps:
+        - browser-tools/install-browser-tools
         - solidusio_extensions/run-tests
 
   workflows:

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -3,8 +3,8 @@ docker:
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1
-      PGUSER: root
+      PGUSER: postgres
       RAILS_ENV: test
   - image: cimg/postgres:14.2
     environment:
-      POSTGRES_USER: root
+      POSTGRES_USER: postgres


### PR DESCRIPTION
This pull request fixes two issues blocking Solidus extensions from running on CI:

1. Create the `postgres` role to fix: "PG::ConnectionBad: FATAL:  role "postgres" does not exist"
2. Call the CircleCI step required to install Google Chrome (https://circleci.com/developer/images/image/cimg/ruby#browsers)

Some examples of failing extensions:
- https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_social/188/workflows/b34f7de8-b3a5-45b0-ab29-dbf98c2352d4/jobs/422
- https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_shipstation/206/workflows/d428bc33-378f-4556-a403-99707b3ebfae/jobs/520
- https://app.circleci.com/pipelines/github/SuperGoodSoft/solidus_taxjar/473/workflows/5a621dbb-a3d5-44f0-8095-cf7cfc36ae92/jobs/650
