### PR TITLE
Store Rails screenshots in artifacts

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -47,6 +47,10 @@ steps:
         SOLIDUS_BRANCH: <<parameters.branch>>
         TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-7-solidus-<<parameters.branch>>/results.xml
       when: always
+  - store_artifacts:
+      name: 'Solidus <<parameters.branch>>: Store spec screenshots'
+      path: spec/dummy/tmp/screenshots
+      destination: screenshots
   - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy
       name: 'Solidus <<parameters.branch>>: Clean up'


### PR DESCRIPTION
When using system specs, Rails automatically generate screenshots for
failing tests using ScreenshotHelper but it has no options to set the
output path.

_Continuing from https://github.com/solidusio/circleci-orbs-extensions/pull/34_
cc @blocknotes