### PR TITLE
Ignore old lock file instead of updating Solidus

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -15,7 +15,7 @@ parameters:
 steps:
   - run:
       name: 'Solidus <<parameters.branch>>: Generate Gemfile.lock'
-      command: bundle lock
+      command: bundle lock --update
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
       when: always
@@ -30,7 +30,6 @@ steps:
       name: 'Solidus <<parameters.branch>>:  Install gems'
       command: |
         bundle install --path=vendor/bundle/<<parameters.branch>> --clean
-        bundle update solidus
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
       when: always


### PR DESCRIPTION
On #44, we added `bundle update solidus` to be sure bundle cache was
invalidated. However, that fails for extensions that don't have solidus
in their Gemfile (e.g., solidus_frontend).

We try another strategy by ignoring the previous lock file when
generating the new one. From `bundle lock --help`:

> Usage:
>   bundle lock
>
> Options:
>       [--update=ignore the existing lockfile, update all gems by default, or update list of given gems]