### PR TITLE
Use local configurations instead of deprecated options for bundler

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -27,9 +27,11 @@ steps:
         - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-
       when: always
   - run:
-      name: 'Solidus <<parameters.branch>>:  Install gems'
+      name: 'Solidus <<parameters.branch>>: Install gems'
       command: |
-        bundle install --path=vendor/bundle/<<parameters.branch>> --clean
+        bundle config set --local clean 'true'
+        bundle config set --local path 'vendor/bundle/<<parameters.branch>>'
+        bundle install
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
       when: always


### PR DESCRIPTION
Both --path and --clean are deprecated:

```
[DEPRECATED] The `--clean` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local clean 'true'`, and stop using this flag
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle/v3.0'`, and stop using this flag
```