### PR TITLE
Allow versions in executors to be parameterized

### DIFF
--- a/src/examples/extension.yml
+++ b/src/examples/extension.yml
@@ -15,17 +15,23 @@ usage:
 
   jobs:
     run-specs-with-postgres:
-      executor: solidusio_extensions/postgres
+      executor:
+        name: solidusio_extensions/postgres
+        ruby_version: '3.1'
       steps:
         - browser-tools/install-browser-tools
         - solidusio_extensions/run-tests
     run-specs-with-mysql:
-      executor: solidusio_extensions/mysql
+      executor:
+        name: solidusio_extensions/mysql
+        ruby_version: '3.0'
       steps:
         - browser-tools/install-browser-tools
         - solidusio_extensions/run-tests
     run-specs-with-sqlite:
-      executor: solidusio_extensions/sqlite
+      executor:
+        name: solidusio_extensions/sqlite
+        ruby_version: '2.7'
       steps:
         - browser-tools/install-browser-tools
         - solidusio_extensions/run-tests

--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -1,12 +1,24 @@
 description: Run specs with MySQL and ElasticSearch
+
+parameters:
+  ruby_version:
+    type: string
+    default: "2.7"
+  mysql_version:
+    type: string
+    default: "5.7"
+  elasticsearch_version:
+    type: string
+    default: "6.8.0"
+
 docker:
-  - image: cimg/ruby:2.7-browsers
+  - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       DB: mysql
       RAILS_ENV: test
       DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
-  - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
-  - image: cimg/mysql:5.7
+  - image: docker.elastic.co/elasticsearch/elasticsearch:<<parameters.elasticsearch_version>>
+  - image: cimg/mysql:<<parameters.mysql_version>>
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
       MYSQL_ROOT_HOST: '%'

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -1,11 +1,20 @@
 description: Run specs with MySQL
+
+parameters:
+  ruby_version:
+    type: string
+    default: "2.7"
+  mysql_version:
+    type: string
+    default: "5.7"
+
 docker:
-  - image: cimg/ruby:2.7-browsers
+  - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       DB: mysql
       RAILS_ENV: test
       DATABASE_URL: mysql2://root@127.0.0.1/circle_test?pool=5
-  - image: cimg/mysql:5.7
+  - image: cimg/mysql:<<parameters.mysql_version>>
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
       MYSQL_ROOT_HOST: '%'

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -1,12 +1,24 @@
 description: Run specs with PostgreSQL and ElasticSearch
+
+parameters:
+  ruby_version:
+    type: string
+    default: "2.7"
+  postgres_version:
+    type: string
+    default: "14.2"
+  elasticsearch_version:
+    type: string
+    default: "6.8.0"
+
 docker:
-  - image: cimg/ruby:2.7-browsers
+  - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1
       PGUSER: root
       RAILS_ENV: test
-  - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
-  - image: cimg/postgres:14.2
+  - image: docker.elastic.co/elasticsearch/elasticsearch:<<parameters.elasticsearch_version>>
+  - image: cimg/postgres:<<parameters.postgres_version>>
     environment:
       POSTGRES_USER: root

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -1,11 +1,20 @@
 description: Run specs with PostgreSQL
+
+parameters:
+  ruby_version:
+    type: string
+    default: "2.7"
+  postgres_version:
+    type: string
+    default: "14.2"
+
 docker:
-  - image: cimg/ruby:2.7-browsers
+  - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       DB: postgresql
       PGHOST: 127.0.0.1
       PGUSER: postgres
       RAILS_ENV: test
-  - image: cimg/postgres:14.2
+  - image: cimg/postgres:<<parameters.postgres_version>>
     environment:
       POSTGRES_USER: postgres

--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -1,6 +1,12 @@
 description: Run specs with an in-memory SQLite
+
+parameters:
+  ruby_version:
+    type: string
+    default: "2.7"
+
 docker:
-  - image: cimg/ruby:2.7-browsers
+  - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       RAILS_ENV: test
       DB: sqlite

--- a/src/executors/sqlite.yml
+++ b/src/executors/sqlite.yml
@@ -1,6 +1,12 @@
 description: Run specs with an in-memory SQLite
+
+parameters:
+  ruby_version:
+    type: string
+    default: "2.7"
+
 docker:
-  - image: cimg/ruby:2.7-browsers
+  - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       RAILS_ENV: test
       DB: sqlite


### PR DESCRIPTION
This will allow us to test against multiple versions of ruby and for newer versions of databases without requiring an update in the Orb.

Fixes #51 