### PR TITLE
Set SKIP_SOLIDUS_BOLT environment variable

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -18,6 +18,7 @@ steps:
       command: bundle lock --update
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
+        SKIP_SOLIDUS_BOLT: "1"
       when: always
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'


### PR DESCRIPTION
solidusio/solidus_frontend#15 fixed the generation of the dummy application used during the extensions testing. However, we still need to pass the SKIP_SOLIDUS_BOLT on Solidus v3.2, where that change hasn't been backported yet. We can revert this commit once that happens.

@elia, I haven't found a way to be more specific and pass the environment variable only to v3.2 (at least without a big restructure). Please, tell me if I'm missing something. Anyway, this is only a temporary fix until the commit in solidus_frontend is backported.

cc @cpfergus1 