### PR TITLE
Drop test database at the end of each test-branch run

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -58,6 +58,15 @@ steps:
       path: spec/dummy/tmp/capybara
       destination: screenshots/capybara
   - run:
+      name: 'Drop database'
+      environment:
+        SOLIDUS_BRANCH: <<parameters.branch>>
+      command: |
+        cd spec/dummy
+        bin/rails db:environment:set RAILS_ENV=test
+        bin/rails db:drop
+      when: always
+  - run:
       command: rm -f Gemfile.lock && rm -fr spec/dummy
       name: 'Solidus <<parameters.branch>>: Clean up'
       when: always


### PR DESCRIPTION
This is a workaround to an issue we're having with the solidus_product_assembly CI, wherein the migrations of a test-branch run appear to load the ActiveRecord models of the previous test-branch run.

Bug description
---------------

```
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column spree_promotions.code does not exist
LINE 1: ..."usage_limit", "spree_promotions"."match_policy", "spree_pro...
                                                             ^
/home/circleci/project/spec/dummy/db/migrate/20221018095939_set_promotions_with_any_policy_to_all_if_possible.spree.rb:6:in `up'
```

See [1][] for a sample of this error.

Based on the error, we think that the migration is expecting that the `spree_promotions` table to have a `code` column.

Cause of the bug
----------------

When setting up the Solidus 3.2 test database, the `common:test_app` ([2][]) would reset and migrate the test database in one call:

```ruby
sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
```

We suspect that the `db:drop` call from the above command loads the ActiveRecord models of the previous test run (Solidus v3.0 branch) and then passes those models to the succeeding db calls: `db:create` and `db:migrate`.

Based on the error, we think that `db:drop` loads a version of the `Spree::Promotion` model that has a `code` attribute. The `SetPromotionsWithAnyPolicyToAllIfPossible` migration then fails when it tries to look for a matching `code` column of this attribute in the `spree_promotions` table.

The error disappears if we remove `solidus_globalize` from the Gemfile, so we suspect that `solidus_globalize` might be the one adding this `code` attribute to the model. See the "Test without globalize" test run ([3][]).

Bug workaround
--------------

In this workaround, we drop the database during the cleanup step of the test-branch command.

Workaround confirmation
-----------------------

See this CI run which applies this workaround to its CircleCI config: [4][].

Possible alternative workaround
-------------------------------

Split the `common:test_app` call as follows:

```ruby
sh "bin/rails db:drop"
sh "bin/rails db:create db:migrate VERBOSE=false RAILS_ENV=test"
```

[1]: https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_product_assembly/298/workflows/fb902d18-0848-4a08-8f07-05b25866e9ff/jobs/687
[2]: https://github.com/solidusio/solidus/blob/d93b67454d8e28cb9b048a3edbb486db06c27c68/core/lib/spree/testing_support/common_rake.rb#L47
[3]: https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_product_assembly/283/workflows/edb49e49-455b-488a-b989-184852eb8606/jobs/668
[4]: https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_product_assembly/301/workflows/1bb37fc3-c4f2-4038-8f5d-fd876d1ee6c8