### PR TITLE
Use master as the default rails version

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -13,7 +13,7 @@ parameters:
     default: Runs tests
   rails_version:
     type: string
-    default: ''
+    default: 'master'
   working_directory:
     type: string
     default: '~/project'


### PR DESCRIPTION
Using an empty string breaks some extension gemfiles looking up the environment variable and using its value as the rails version to use. When it's an empty string they end up with `gem 'rails', ''` in the Gemfile, which is not supported.