### PR TITLE
Fix the default rails version

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -13,7 +13,7 @@ parameters:
     default: Runs tests
   rails_version:
     type: string
-    default: 'master'
+    default: '>0.a'
   working_directory:
     type: string
     default: '~/project'


### PR DESCRIPTION
## Summary

_Take 2_

"master" is not a valid version, switching to `null` hoping that the environment variable will turn out as `nil` in Ruby.

Ref: https://github.com/solidusio/solidus_paypal_commerce_platform/pull/139
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
