### PR TITLE
Match the Rails name for sqlite in `$DB`

### DIFF
--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -9,6 +9,6 @@ docker:
   - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       RAILS_ENV: test
-      DB: sqlite
+      DB: sqlite3
       DATABASE_URL: sqlite3::memory:?pool=1
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true

--- a/src/executors/sqlite.yml
+++ b/src/executors/sqlite.yml
@@ -9,4 +9,4 @@ docker:
   - image: cimg/ruby:<<parameters.ruby_version>>-browsers
     environment:
       RAILS_ENV: test
-      DB: sqlite
+      DB: sqlite3


### PR DESCRIPTION


## Summary

We traditionally used `sqlite` and had code to convert it to `sqlite3` when using it as a `rails new --database=…` option.
Moving to use the same naming simplifies the setup. Sandbox and solidus_core script should already be compatible with the rails-compatible name.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
