### PR TITLE
Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,23 +4,36 @@ orbs:
   # https://circleci.com/developer/orbs/orb/circleci/orb-tools
   orb-tools: circleci/orb-tools@11.1
   shellcheck: circleci/shellcheck@3.1
+  slack: circleci/slack@4.9.3
 
 filters: &filters
   tags:
     only: /.*/
+
+with_notification: &with_notification
+  context: slack-secrets
+  post-steps:
+    - slack/notify:
+        event: fail
+        template: basic_fail_1
+        branch_pattern: master
 
 workflows:
   lint-pack:
     jobs:
       - orb-tools/lint:
           filters: *filters
+          <<: *with_notification
       - orb-tools/pack:
           filters: *filters
+          <<: *with_notification
       - orb-tools/review:
           filters: *filters
           exclude: RC009 # 64 is too short as the commands line lenth limit
+          <<: *with_notification
       - shellcheck/check:
           filters: *filters
+          <<: *with_notification
       - orb-tools/publish:
           orb-name: solidusio/extensions
           vcs-type: << pipeline.project.type >>
@@ -28,9 +41,11 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters
+          <<: *with_notification
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
           vcs-type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters
+          <<: *with_notification


### PR DESCRIPTION
## Summary

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2)  channel on Solidus' [Slack workspace](https://soliidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202761161-c405a031-1277-407b-b721-0a9bc68e4acc.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
