### PR TITLE
[DRAFT] Bump Elasticsearch versions for its executors

### DIFF
--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -9,7 +9,7 @@ parameters:
     default: "5.7"
   elasticsearch_version:
     type: string
-    default: "6.8.0"
+    default: "8.5.3"
 
 docker:
   - image: cimg/ruby:<<parameters.ruby_version>>-browsers

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -9,7 +9,7 @@ parameters:
     default: "14.2"
   elasticsearch_version:
     type: string
-    default: "6.8.0"
+    default: "8.5.3"
 
 docker:
   - image: cimg/ruby:<<parameters.ruby_version>>-browsers


### PR DESCRIPTION
## Summary

The version needs to match the version used by the extensions that need ES running in the CI for testing purposes.

This is the related failure on solidus_searchkick: https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_searchkick/190/workflows/41f8bce8-4f88-42e0-bb41-d5deea23e233/jobs/446

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
