### PR TITLE
Track the ruby version in the cache key

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -28,12 +28,17 @@ steps:
         RAILS_VERSION: <<parameters.rails_version>>
         SKIP_SOLIDUS_BOLT: "1"
       when: always
+  - run:
+      name: 'Solidus <<parameters.branch>>: Generate .ruby-version'
+      working_directory: <<parameters.working_directory>>
+      command: ruby -e "puts RUBY_VERSION" > .ruby-version
+      when: always
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
-        - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "<<parameters.working_directory>>/Gemfile.lock" }}
-        - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-master
-        - gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-
+        - gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "<<parameters.working_directory>>/Gemfile.lock" }}
+        - gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-master
+        - gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-
       when: always
   - run:
       name: 'Solidus <<parameters.branch>>: Install gems'
@@ -48,7 +53,7 @@ steps:
       when: always
   - save_cache:
       name: 'Solidus <<parameters.branch>>: Save Bundler cache'
-      key: gems-v3-ruby-v2-7-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "<<parameters.working_directory>>/Gemfile.lock" }}
+      key: gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "<<parameters.working_directory>>/Gemfile.lock" }}
       paths:
         - <<parameters.working_directory>>/vendor/bundle/<<parameters.branch>>
       when: always


### PR DESCRIPTION
## Summary

We started allowing to use different ruby version but was never included in the cache key.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
