### PR TITLE
Add supported v3.1, and use older Rails on it

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -9,5 +9,9 @@ parameters:
 steps:
   - test-branch:
       branch: v3.2
+      rails_version: '~> 7.0'
+      working_directory: <<parameters.working_directory>>
+  - test-branch:
+      branch: v3.1
       rails_version: '~> 6.1'
       working_directory: <<parameters.working_directory>>


### PR DESCRIPTION
## Summary

We removed support for v3.1 on https://github.com/solidusio/circleci-orbs-extensions/pull/73. However, it'll reach [EOL on 2023-03-10](https://solidus.io/security/).

We'll cover older Rails with it, while using Rails v7 for Solidus v3.2.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.
- ~[ ] I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).~

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
