### PR TITLE
Simplify the default test results path

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -59,7 +59,7 @@ steps:
       environment:
         SOLIDUS_BRANCH: <<parameters.branch>>
         RAILS_VERSION: <<parameters.rails_version>>
-        TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-7-solidus-<<parameters.branch>>/results.xml
+        TEST_RESULTS_PATH: test-results/solidus-<<parameters.branch>>/results.xml
       when: always
   - store_artifacts:
       name: 'Solidus <<parameters.branch>>: Store Rails screenshots'


### PR DESCRIPTION
## Summary

We're using dynamic test results paths because for extensions using an
older setup different solidus versions are tested within the same job.

However, we don't need to mimic the entire cache key as path. CircleCI
doesn't interpolate everything within environment variable values, so
breaking this coupling will help in the future.

Closes #78

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
