### PR TITLE
Allow individual extensions to clear bundler cache

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -36,9 +36,9 @@ steps:
   - restore_cache:
       name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
       keys:
-        - gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "<<parameters.working_directory>>/Gemfile.lock" }}
-        - gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-master
-        - gems-v3-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-
+        - gems-v3.{{ .Environment.CACHE_VERSION }}-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "<<parameters.working_directory>>/Gemfile.lock" }}
+        - gems-v3.{{ .Environment.CACHE_VERSION }}-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-master
+        - gems-v3.{{ .Environment.CACHE_VERSION }}-ruby-{{ checksum "<<parameters.working_directory>>/.ruby-version" }}-solidus-<<parameters.branch>>-
       when: always
   - run:
       name: 'Solidus <<parameters.branch>>: Install gems'


### PR DESCRIPTION
## Summary

Allow extensions to invalidate bundle cache

Until now, there were no way for an extension to invalidate its bundle cache. Instead, it was needed to bump the cache version upstream in the orb's code. That also meant that all of the extensions cache was invalidated at once.

We're now giving control to individual extensions by adding a `CACHE_VERSION` [environment variable to the cache keys](https://support.circleci.com/hc/en-us/articles/115015426888-Clear-Project-Dependency-Cache). When no present in the extension's environment, it'll take a value equal to `<no value>`, and it can be added and bumped to invalidate it.

Closes #77

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
