### PR TITLE
Remove v3.1 from older Solidus

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -15,7 +15,3 @@ steps:
       branch: v3.2
       rails_version: '~> 7.0'
       working_directory: <<parameters.working_directory>>
-  - test-branch:
-      branch: v3.1
-      rails_version: '~> 6.1'
-      working_directory: <<parameters.working_directory>>


### PR DESCRIPTION
## Summary

That version is [EOL since 2023-03-10](https://solidus.io/security/).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
