### PR TITLE
Fix CI by explicitly passing ruby version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -9,28 +9,36 @@ filters: &filters
 
 jobs:
   test-run-with-postgres:
-    executor: extensions/postgres
+    executor:
+      name: extensions/postgres
+      ruby_version: "3.0"
     steps:
       - checkout
       - extensions/run-tests-solidus-older:
           working_directory: '~/project/solidus_dummy_extension'
       - extensions/store-test-results
   test-run-with-mysql:
-    executor: extensions/mysql
+    executor:
+      name: extensions/mysql
+      ruby_version: "3.1"
     steps:
       - checkout
       - extensions/run-tests-solidus-current:
           working_directory: '~/project/solidus_dummy_extension'
       - extensions/store-test-results
   test-run-with-sqlite:
-    executor: extensions/sqlite
+    executor:
+      name: extensions/sqlite
+      ruby_version: "3.2"
     steps:
       - checkout
       - extensions/run-tests-solidus-master:
           working_directory: '~/project/solidus_dummy_extension'
       - extensions/store-test-results
   test-run-linting-code:
-    executor: extensions/sqlite-memory
+    executor:
+      name: extensions/sqlite-memory
+      ruby_version: "3.2"
     steps:
       - extensions/lint-code:
           working_directory: '~/project/solidus_dummy_extension'

--- a/solidus_dummy_extension/.rubocop.yml
+++ b/solidus_dummy_extension/.rubocop.yml
@@ -3,3 +3,6 @@ require:
 
 AllCops:
   NewCops: disable
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false


### PR DESCRIPTION
## Summary

Ruby 2.7 is no longer supported on Solidus' master.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
