### PR TITLE
Update from Ruby 2.7 to 3.0

### DIFF
--- a/src/examples/extension.yml
+++ b/src/examples/extension.yml
@@ -38,7 +38,7 @@ usage:
   lint-code:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '2.7'
+      ruby_version: '3.0'
     steps:
       - solidusio_extensions/lint-code
 

--- a/src/executors/mysql-elasticsearch.yml
+++ b/src/executors/mysql-elasticsearch.yml
@@ -3,7 +3,7 @@ description: Run specs with MySQL and ElasticSearch
 parameters:
   ruby_version:
     type: string
-    default: "2.7"
+    default: "3.0"
   mysql_version:
     type: string
     default: "5.7"

--- a/src/executors/mysql.yml
+++ b/src/executors/mysql.yml
@@ -3,7 +3,7 @@ description: Run specs with MySQL
 parameters:
   ruby_version:
     type: string
-    default: "2.7"
+    default: "3.0"
   mysql_version:
     type: string
     default: "5.7"

--- a/src/executors/postgres-elasticsearch.yml
+++ b/src/executors/postgres-elasticsearch.yml
@@ -3,7 +3,7 @@ description: Run specs with PostgreSQL and ElasticSearch
 parameters:
   ruby_version:
     type: string
-    default: "2.7"
+    default: "3.0"
   postgres_version:
     type: string
     default: "14.2"

--- a/src/executors/postgres.yml
+++ b/src/executors/postgres.yml
@@ -3,7 +3,7 @@ description: Run specs with PostgreSQL
 parameters:
   ruby_version:
     type: string
-    default: "2.7"
+    default: "3.0"
   postgres_version:
     type: string
     default: "14.2"

--- a/src/executors/sqlite-memory.yml
+++ b/src/executors/sqlite-memory.yml
@@ -3,7 +3,7 @@ description: Run specs with an in-memory SQLite
 parameters:
   ruby_version:
     type: string
-    default: "2.7"
+    default: "3.0"
 
 docker:
   - image: cimg/ruby:<<parameters.ruby_version>>-browsers

--- a/src/executors/sqlite.yml
+++ b/src/executors/sqlite.yml
@@ -3,7 +3,7 @@ description: Run specs with an in-memory SQLite
 parameters:
   ruby_version:
     type: string
-    default: "2.7"
+    default: "3.0"
 
 docker:
   - image: cimg/ruby:<<parameters.ruby_version>>-browsers


### PR DESCRIPTION
Ruby 2.7 has been end-of-lifed: https://endoflife.date/ruby.

Not updating to 3.0 can cause dependency installation issues. For example: extensions that use `selenium-webdrivers`, `~> 4.11`, require Ruby 3 at a minimum.
