### PR TITLE
Allow single-file Dummy App in extensions

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -82,10 +82,13 @@ steps:
       working_directory: <<parameters.working_directory>>
       command: |
         # Not all commands will create a spec/dummy folder (e.g. the linter job)
-        if [[ -d "spec/dummy" ]]; then
+        if [[ -e "spec/dummy/bin/rails" ]]; then
           cd spec/dummy && \
             bin/rails db:environment:set RAILS_ENV=test && \
             bin/rails db:drop
+        # Not all dummy apps have executables
+        elif [[ -e bin/rake ]]; then
+          bin/rake db:drop
         fi
       when: always
   - run:


### PR DESCRIPTION
This fixes the cleanup task of the test-branch file that is run in every test. For extensions that use Solidus core's `DummyApp` rather than the dummy app generated by the solidus_dev_support extension, there are no executables. Cleanup happens via a Raketask supplied by Solidus itself.

Fixes spec failures such as this one https://app.circleci.com/pipelines/github/friendlycart/solidus_friendly_promotions/471/workflows/14e177b0-508e-4ed1-8943-e0163720785a/jobs/1548
 when using the Solidus core dummy app in extensions like here https://github.com/friendlycart/solidus_friendly_promotions/pull/124.
