### PR TITLE
Restrict SQLite to 1.x

### DIFF
--- a/solidus_dummy_extension/Gemfile
+++ b/solidus_dummy_extension/Gemfile
@@ -21,7 +21,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 # While we still support Ruby < 3 we need to workaround a limitation in


### PR DESCRIPTION
SQLite has 2.0 out, but ActiveRecord still relies on 1.x in their generators.
