### PR TITLE
Drop database only if dummy app present

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -87,7 +87,7 @@ steps:
             bin/rails db:environment:set RAILS_ENV=test && \
             bin/rails db:drop
         # Not all dummy apps have executables
-        elif [[ -e bin/rake ]]; then
+        elif [[ -e bin/rake ]] && [[ -d "spec/dummy" ]]; then
           bin/rake db:drop
         fi
       when: always


### PR DESCRIPTION
Some extensions have rake defined, but no dummy app and therefore no database (i.e. solidus_dev_support). In these cases we don't need to run `rake db:drop`.
