### PR TITLE
Fix requirements for older solidus versions

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -9,17 +9,17 @@ parameters:
 steps:
   - test-branch:
       branch: v4.3
-      rails_version: "~> 7.1"
+      rails_version: '~> 7.1.0'
       working_directory: <<parameters.working_directory>>
   - test-branch:
       branch: v4.2
-      rails_version: "~> 7.0"
+      rails_version: '~> 7.0.0'
       working_directory: <<parameters.working_directory>>
   - test-branch:
       branch: v4.1
-      rails_version: "~> 7.0"
+      rails_version: '~> 7.0.0'
       working_directory: <<parameters.working_directory>>
   - test-branch:
       branch: v4.0
-      rails_version: "~> 7.0"
+      rails_version: '~> 7.0.0'
       working_directory: <<parameters.working_directory>>


### PR DESCRIPTION
Solidus 4.0 through 4.2 are not compatible with Rails 7.2, but the version requirement `~> 7.0`  allows Rails 7.2.
