### PR TITLE
Remove Solidus 4.0 builds

### DIFF
--- a/src/commands/run-tests-solidus-older.yml
+++ b/src/commands/run-tests-solidus-older.yml
@@ -19,7 +19,3 @@ steps:
       branch: v4.1
       rails_version: '~> 7.0.0'
       working_directory: <<parameters.working_directory>>
-  - test-branch:
-      branch: v4.0
-      rails_version: '~> 7.0.0'
-      working_directory: <<parameters.working_directory>>


### PR DESCRIPTION
Solidus 4.0 is not supported anymore. EOL was 2024-11-08
