### PR TITLE
Set default Rails version to v7.0

### DIFF
--- a/src/commands/test-branch.yml
+++ b/src/commands/test-branch.yml
@@ -13,7 +13,7 @@ parameters:
     default: Runs tests
   rails_version:
     type: string
-    default: '>0.a'
+    default: '~> 7.0'
   working_directory:
     type: string
     default: '~/project'


### PR DESCRIPTION
This is the minimum version we support.
In order to prevent installing Rails 8.0
during extension specs we need to default
to the 7.x version.
